### PR TITLE
Make pages responsive

### DIFF
--- a/src/BrasilPage.jsx
+++ b/src/BrasilPage.jsx
@@ -1,6 +1,7 @@
 import * as d3 from 'd3';
 import { useEffect, useRef } from 'react';
 import { useState } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 
@@ -206,6 +207,9 @@ export default function BrasilPage({ onBack, onNext }) {
   });
   const datosGraf2 = datosMunicipio.filter(d => d.tiempo_prestamo > 13);
 
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+
   // Cálculo de métricas para los botones
   // Promedio anual de aprobaciones EXTERNAS últimos 5 años (en millones USD)
   const now = new Date();
@@ -253,6 +257,8 @@ export default function BrasilPage({ onBack, onNext }) {
       porcentajeExterna: total > 0 ? (100 * externos / total).toFixed(1) : '0.0'
     };
   });
+
+  const chartWidth = Math.min(600, windowWidth - (isMobile ? 40 : 200));
 
   return (
     <div style={{ background: '#f7f7f9', padding: '0', position: 'relative' }}>
@@ -307,8 +313,8 @@ export default function BrasilPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          top: 100,
-          right: 32,
+          top: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -333,8 +339,8 @@ export default function BrasilPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          bottom: 100,
-          right: 32,
+          bottom: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -349,27 +355,27 @@ export default function BrasilPage({ onBack, onNext }) {
       >
         <FaArrowUp style={{ fontSize: 36, color: '#c1121f', transform: 'rotate(180deg)' }} />
       </div>
-      <div style={{ display: 'flex', gap: '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: 'calc(100vh - 72px)' }}>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? '1.5rem' : '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: isMobile ? 'auto' : 'calc(100vh - 72px)' }}>
         {/* Izquierda: Card descriptivo con título y texto */}
         <div
           style={{
             flex: 1,
-            minWidth: 380,
-            maxWidth: 480,
+            minWidth: isMobile ? '100%' : 320,
+            maxWidth: isMobile ? '100%' : 480,
             background: '#fff',
             borderRadius: 0,
             boxShadow: '0 4px 24px #0001',
             border: 'none',
             marginLeft: 0,
-            marginTop: '3.7rem',
+            marginTop: isMobile ? '1.5rem' : '3.7rem',
             marginBottom: 0,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-start',
             padding: '2.5rem 2rem 2rem 2rem',
             boxSizing: 'border-box',
-            height: '100%',
-            minHeight: '100%',
+            height: isMobile ? 'auto' : '100%',
+            minHeight: isMobile ? 'auto' : '100%',
             position: 'relative',
             zIndex: 2,
             width: '100%',
@@ -409,7 +415,7 @@ export default function BrasilPage({ onBack, onNext }) {
           </div>
         </div>
         {/* Derecha: Gráficos */}
-        <div style={{ flex: 1, minWidth: 350, maxWidth: 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 56, paddingTop: 0, paddingLeft: 0, marginTop: 56 }}>
+        <div style={{ flex: 1, minWidth: isMobile ? '100%' : 300, maxWidth: isMobile ? '100%' : 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: isMobile ? 0 : 56, paddingTop: 0, paddingLeft: 0, marginTop: isMobile ? 20 : 56 }}>
           {/* Métricas tipo botón arriba de los gráficos */}
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 32, marginBottom: 18, marginTop: '-2.5rem', marginLeft: 0 }}>
             <div style={{ background: '#f3f4f7', color: '#444', fontSize: '0.98rem', fontWeight: 500, borderRadius: 0, padding: '0.7em 1.6em 0.7em 1.2em', boxShadow: '0 1px 6px #0001', display: 'flex', alignItems: 'center', minWidth: 220, position: 'relative', fontFamily: 'inherit', border: 'none', marginRight: 0 }}>
@@ -429,7 +435,7 @@ export default function BrasilPage({ onBack, onNext }) {
             <span style={{ color: '#888', fontWeight: 600, fontSize: '1.01rem', letterSpacing: '0.01em' }}>Interno</span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexDirection: 'row' }}>
-            <BarChartD3 data={datosGraf1} colorMap={colorMap} width={600} height={260} showXAxis={false} extendRefLinesDown={true} />
+            <BarChartD3 data={datosGraf1} colorMap={colorMap} width={chartWidth} height={260} showXAxis={false} extendRefLinesDown={true} />
             <div style={{ display: 'flex', alignItems: 'center', height: 260, marginRight: 8, justifyContent: 'center' }}>
               <div style={{ border: '2px solid #c1121f', borderRadius: 20, background: 'rgba(255,255,255,0.0)', color: '#c1121f', fontSize: '0.95rem', fontFamily: 'inherit', fontWeight: 500, letterSpacing: '0.01em', boxSizing: 'border-box', padding: '0.2em 1.2em', minWidth: 120, textAlign: 'center', whiteSpace: 'nowrap', display: 'inline-block', transform: 'rotate(90deg)', transformOrigin: 'center center' }}>
                 Plazo &gt; 0 Años
@@ -437,7 +443,7 @@ export default function BrasilPage({ onBack, onNext }) {
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexDirection: 'row' }}>
-            <BarChartD3 data={datosGraf2} colorMap={colorMap} width={600} height={260} showXAxis={true} showXAxisTicksOnly={true} />
+            <BarChartD3 data={datosGraf2} colorMap={colorMap} width={chartWidth} height={260} showXAxis={true} showXAxisTicksOnly={true} />
             <div style={{ display: 'flex', alignItems: 'center', height: 260, marginRight: 8, justifyContent: 'center' }}>
               <div style={{ border: '2px solid #c1121f', borderRadius: 20, background: 'rgba(255,255,255,0.0)', color: '#c1121f', fontSize: '0.95rem', fontFamily: 'inherit', fontWeight: 500, letterSpacing: '0.01em', boxSizing: 'border-box', padding: '0.2em 1.2em', minWidth: 120, textAlign: 'center', whiteSpace: 'nowrap', display: 'inline-block', transform: 'rotate(90deg)', transformOrigin: 'center center' }}>
                 Plazo &gt; 13 Años

--- a/src/ClustersPage.jsx
+++ b/src/ClustersPage.jsx
@@ -1,6 +1,7 @@
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 import { useEffect, useRef, useState } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 
 // Datos de clusters visualizados con PCA (completo, según el usuario)
 const CLUSTERS_DATA = [
@@ -390,6 +391,9 @@ export default function ClustersPage({ onBack, onNext }) {
   // No se usa API, los datos están embebidos
   const [vista, setVista] = useState('clusters'); // Siempre inicia en clusters
   const [d3Ready, setD3Ready] = useState(!!window.d3);
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+  const chartWidth = Math.min(750, windowWidth - (isMobile ? 40 : 200));
   useEffect(() => {
     if (!window.d3) {
       const script = document.createElement('script');
@@ -455,8 +459,8 @@ export default function ClustersPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          top: 80,
-          right: 32,
+          top: isMobile ? 60 : 80,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -481,8 +485,8 @@ export default function ClustersPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          bottom: 40,
-          right: 32,
+          bottom: isMobile ? 40 : 40,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -497,27 +501,27 @@ export default function ClustersPage({ onBack, onNext }) {
       >
         <FaArrowUp style={{ fontSize: 36, color: '#c1121f', transform: 'rotate(180deg)' }} />
       </div>
-      <div style={{ display: 'flex', gap: '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: 'calc(100vh - 72px)' }}>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? '1.5rem' : '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: isMobile ? 'auto' : 'calc(100vh - 72px)' }}>
         {/* Izquierda: Card descriptivo con título y texto */}
         <div
           style={{
             flex: 1,
-            minWidth: 380,
-            maxWidth: 480,
+            minWidth: isMobile ? '100%' : 320,
+            maxWidth: isMobile ? '100%' : 480,
             background: '#fff',
             borderRadius: 0,
             boxShadow: '0 4px 24px #0001',
             border: 'none',
             marginLeft: 0,
-            marginTop: '3.7rem',
+            marginTop: isMobile ? '1.5rem' : '3.7rem',
             marginBottom: 0,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-start',
             padding: '2.5rem 2rem 2rem 2rem',
             boxSizing: 'border-box',
-            height: '100%',
-            minHeight: '100%',
+            height: isMobile ? 'auto' : '100%',
+            minHeight: isMobile ? 'auto' : '100%',
             position: 'relative',
             zIndex: 2,
             width: '100%',
@@ -535,7 +539,7 @@ export default function ClustersPage({ onBack, onNext }) {
           </div>
         </div>
         {/* Derecha: Header con título y botones alineados, y espacio para gráficos o insights */}
-        <div style={{ flex: 1, minWidth: 350, maxWidth: 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 0, paddingTop: 0, paddingLeft: 0, marginTop: '3.7rem' }}>
+        <div style={{ flex: 1, minWidth: isMobile ? '100%' : 300, maxWidth: isMobile ? '100%' : 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: isMobile ? 0 : 0, paddingTop: 0, paddingLeft: 0, marginTop: isMobile ? 20 : '3.7rem' }}>
           {/* Header: solo los botones, sin título duplicado */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 24, width: '100%' }}>
             <div style={{ display: 'flex', gap: 32 }}>
@@ -570,7 +574,7 @@ export default function ClustersPage({ onBack, onNext }) {
           {/* Visualización: gráfico o tabla, ambos del mismo tamaño visual */}
           <div style={{ width: '100%', height: 600, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: '1.2rem', background: 'transparent' }}>
             {vista === 'clusters' ? (
-              d3Ready ? <ScatterPlotClusters data={CLUSTERS_DATA} width={750} height={600} /> : <div style={{color:'#888', fontSize:16}}>Cargando gráfico...</div>
+              d3Ready ? <ScatterPlotClusters data={CLUSTERS_DATA} width={chartWidth} height={600} /> : <div style={{color:'#888', fontSize:16}}>Cargando gráfico...</div>
             ) : (
               <div style={{ width: '100%' }}><ClusterInsightsTable /></div>
             )}

--- a/src/DescripcionMercadoPage.jsx
+++ b/src/DescripcionMercadoPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 import ScatterPlot from './components/ScatterPlot';
@@ -20,6 +21,9 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
   const [vista, setVista] = useState('todos');
   const [ocultos, setOcultos] = useState([]); // categorías ocultas
   const [yMax, setYMax] = useState(115);
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+  const chartWidth = Math.min(650, windowWidth - (isMobile ? 40 : 200));
 
   // Altura y margen del área útil del gráfico
   const plotHeight = 500; // 600 - 40 (top) - 60 (bottom)
@@ -116,8 +120,8 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          top: 100,
-          right: 32,
+          top: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -142,8 +146,8 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          bottom: 100,
-          right: 32,
+          bottom: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -158,27 +162,27 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
       >
         <FaArrowUp style={{ fontSize: 36, color: '#c1121f', transform: 'rotate(180deg)' }} />
       </div>
-      <div style={{ display: 'flex', gap: '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: 'calc(100vh - 72px)' }}>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? '1.5rem' : '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: isMobile ? 'auto' : 'calc(100vh - 72px)' }}>
         {/* Izquierda: Card descriptivo con título y texto */}
         <div
           style={{
             flex: 1,
-            minWidth: 380,
-            maxWidth: 480,
+            minWidth: isMobile ? '100%' : 320,
+            maxWidth: isMobile ? '100%' : 480,
             background: '#fff',
             borderRadius: 0,
             boxShadow: '0 4px 24px #0001',
             border: 'none',
             marginLeft: 0,
-            marginTop: '3.7rem',
+            marginTop: isMobile ? '1.5rem' : '3.7rem',
             marginBottom: 0,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-start',
             padding: '2.5rem 2rem 2rem 2rem',
             boxSizing: 'border-box',
-            height: '100%',
-            minHeight: '100%',
+            height: isMobile ? 'auto' : '100%',
+            minHeight: isMobile ? 'auto' : '100%',
             position: 'relative',
             zIndex: 2,
             width: '100%',
@@ -240,7 +244,7 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
           </div>
         </div>
         {/* Derecha: Espacio para gráficos */}
-        <div style={{ flex: 1, minWidth: 350, maxWidth: 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 0, paddingTop: 0, paddingLeft: 0, marginTop: 100 }}>
+        <div style={{ flex: 1, minWidth: isMobile ? '100%' : 300, maxWidth: isMobile ? '100%' : 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: isMobile ? 0 : 0, paddingTop: 0, paddingLeft: 0, marginTop: isMobile ? 60 : 100 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', width: '100%' }}>
             {/* Slider vertical para eje Y */}
             {/* Altura del área útil del gráfico */}
@@ -369,7 +373,7 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
               `}</style>
             </div>
             <div style={{ width: '100%', height: 600, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: '1.2rem', background: 'transparent' }}>
-              <ScatterPlot datos={datos} width={650} height={600} acreedoresMostrar={acreedoresFiltrados} colorOverride={colorOverride} onLegendClick={handleToggleAcreedor} legendActive={a => !ocultos.includes(a)} legendOrder={acreedoresMostrar} yMax={yMax || LIMITE_MAXIMO} />
+              <ScatterPlot datos={datos} width={chartWidth} height={600} acreedoresMostrar={acreedoresFiltrados} colorOverride={colorOverride} onLegendClick={handleToggleAcreedor} legendActive={a => !ocultos.includes(a)} legendOrder={acreedoresMostrar} yMax={yMax || LIMITE_MAXIMO} />
             </div>
           </div>
         </div>

--- a/src/FinanciadorMontosPage.jsx
+++ b/src/FinanciadorMontosPage.jsx
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import { useEffect, useRef, useState } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 import BoxPlot from './components/BoxPlot';
@@ -20,6 +21,9 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
   const acreedoresExteriores = ['FONPLATA', 'BID', 'NDB', 'CAF', 'BIRF'];
   const acreedoresInternos = ['FONPLATA', 'Caixa', 'BNDS'];
   const acreedoresTodos = ['Caixa', 'FONPLATA', 'BNDS', 'BID', 'NDB', 'CAF', 'BIRF'];
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+  const chartWidth = Math.min(700, windowWidth - (isMobile ? 40 : 200));
   let acreedoresMostrar = acreedoresExteriores;
   if (vista === 'internos') acreedoresMostrar = acreedoresInternos;
   if (vista === 'todos') acreedoresMostrar = acreedoresTodos;
@@ -91,8 +95,8 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          top: 100,
-          right: 32,
+          top: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -117,8 +121,8 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          bottom: 100,
-          right: 32,
+          bottom: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -133,27 +137,27 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
       >
         <FaArrowUp style={{ fontSize: 36, color: '#c1121f', transform: 'rotate(180deg)' }} />
       </div>
-      <div style={{ display: 'flex', gap: '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: 'calc(100vh - 72px)' }}>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? '1.5rem' : '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: isMobile ? 'auto' : 'calc(100vh - 72px)' }}>
         {/* Izquierda: Card descriptivo con título y texto */}
         <div
           style={{
             flex: 1,
-            minWidth: 380,
-            maxWidth: 480,
+            minWidth: isMobile ? '100%' : 320,
+            maxWidth: isMobile ? '100%' : 480,
             background: '#fff',
             borderRadius: 0,
             boxShadow: '0 4px 24px #0001',
             border: 'none',
             marginLeft: 0,
-            marginTop: '3.7rem',
+            marginTop: isMobile ? '1.5rem' : '3.7rem',
             marginBottom: 0,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-start',
             padding: '2.5rem 2rem 2rem 2rem',
             boxSizing: 'border-box',
-            height: '100%',
-            minHeight: '100%',
+            height: isMobile ? 'auto' : '100%',
+            minHeight: isMobile ? 'auto' : '100%',
             position: 'relative',
             zIndex: 2,
             width: '100%',
@@ -178,7 +182,7 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
           </div>
         </div>
         {/* Derecha: Espacio para gráficos */}
-        <div style={{ flex: 1, minWidth: 350, maxWidth: 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 56, paddingTop: 0, paddingLeft: 0, marginTop: 140 }}>
+        <div style={{ flex: 1, minWidth: isMobile ? '100%' : 300, maxWidth: isMobile ? '100%' : 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: isMobile ? 0 : 56, paddingTop: 0, paddingLeft: 0, marginTop: isMobile ? 60 : 140 }}>
           {/* Botones para cambiar de vista */}
           <div style={{ display: 'flex', gap: 32, marginBottom: 40, justifyContent: 'center', marginTop: -16 }}>
             <span
@@ -223,7 +227,7 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
           </div>
           {/* Aquí puedes agregar los componentes de gráficos que desees */}
           <div style={{ width: '100%', height: 400, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: '1.2rem', background: 'transparent' }}>
-            <BoxPlot datos={datos} width={700} height={450} acreedoresMostrar={acreedoresMostrar} />
+            <BoxPlot datos={datos} width={chartWidth} height={450} acreedoresMostrar={acreedoresMostrar} />
           </div>
         </div>
       </div>

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useRef, useState, useEffect } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 import Particles from 'react-tsparticles';
 import { loadFull } from 'tsparticles';
 import fonpilogo from './assets/fonpilogo.png';
@@ -47,6 +48,9 @@ export default function HomePage() {
   const [selectedCountry, setSelectedCountry] = useState(null);
   const [geoData, setGeoData] = useState(null);
   const svgRef = useRef();
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+  const mapWidth = Math.min(520, windowWidth - (isMobile ? 40 : 200));
 
   useEffect(() => {
     fetch('/geojson/southamerica.json')
@@ -190,18 +194,18 @@ export default function HomePage() {
         </div>
         <div style={{
           display: 'flex',
-          flexDirection: 'row',
+          flexDirection: isMobile ? 'column' : 'row',
           alignItems: 'center',
           justifyContent: 'center',
           width: '100%',
           maxWidth: 1200,
           margin: '0 auto',
           zIndex: 2,
-          gap: 32,
+          gap: isMobile ? 16 : 32,
           position: 'relative',
         }}>
           {/* Columna izquierda: texto y barra de selección */}
-          <div style={{flex: 1, minWidth: 320, maxWidth: 500, paddingRight: 32}}>
+          <div style={{flex: 1, minWidth: isMobile ? '100%' : 320, maxWidth: isMobile ? '100%' : 500, paddingRight: isMobile ? 0 : 32}}>
             <h1 style={{color: '#c1121f', fontWeight: 700, fontSize: '2.5rem', marginBottom: 16}}>Contexto Estratégico</h1>
             {/* Buscador de país moderno */}
             <div style={{ marginBottom: 24, position: 'relative', maxWidth: 320 }}>
@@ -290,8 +294,8 @@ export default function HomePage() {
             </button>
           </div>
           {/* Columna derecha: globo terraqueo SVG realista de Sudamérica */}
-          <div style={{flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', minWidth: 520, position: 'relative'}}>
-            <svg ref={svgRef} viewBox="0 0 520 520" width="520" height="520" style={{background: 'none'}}>
+          <div style={{flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', minWidth: isMobile ? '100%' : 520, position: 'relative'}}>
+            <svg ref={svgRef} viewBox="0 0 520 520" width={mapWidth} height={mapWidth} style={{background: 'none'}}>
               <circle cx="250" cy="260" r="240" fill="none" stroke="#111" strokeWidth="0.7" />
               <g id="paises" />
             </svg>

--- a/src/OportunidadesPage.jsx
+++ b/src/OportunidadesPage.jsx
@@ -1,12 +1,16 @@
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 import { useEffect, useState } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 import { FaChevronDown, FaChevronRight } from 'react-icons/fa';
 
 export default function OportunidadesPage({ onBack, onNext }) {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+  const tableWidth = Math.min(730, windowWidth - (isMobile ? 40 : 200));
   return (
     <div style={{ background: '#f7f7f9', padding: '0', position: 'relative' }}>
       {/* Barra superior con logo y botón */}
@@ -60,8 +64,8 @@ export default function OportunidadesPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          top: 80,
-          right: 32,
+          top: isMobile ? 60 : 80,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -89,27 +93,27 @@ export default function OportunidadesPage({ onBack, onNext }) {
       >
         <FaArrowUp style={{ fontSize: 36, color: '#c1121f', transform: 'rotate(180deg)' }} />
       </div> */}
-      <div style={{ display: 'flex', gap: '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: 'calc(100vh - 72px)' }}>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? '1.5rem' : '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: isMobile ? 'auto' : 'calc(100vh - 72px)' }}>
         {/* Izquierda: Card descriptivo con título y texto */}
         <div
           style={{
             flex: 1,
-            minWidth: 380,
-            maxWidth: 480,
+            minWidth: isMobile ? '100%' : 320,
+            maxWidth: isMobile ? '100%' : 480,
             background: '#fff',
             borderRadius: 0,
             boxShadow: '0 4px 24px #0001',
             border: 'none',
             marginLeft: 0,
-            marginTop: '3.7rem',
+            marginTop: isMobile ? '1.5rem' : '3.7rem',
             marginBottom: 0,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-start',
             padding: '2.5rem 2rem 2rem 2rem',
             boxSizing: 'border-box',
-            height: '100%',
-            minHeight: '100%',
+            height: isMobile ? 'auto' : '100%',
+            minHeight: isMobile ? 'auto' : '100%',
             position: 'relative',
             zIndex: 2,
             width: '100%',
@@ -130,8 +134,8 @@ export default function OportunidadesPage({ onBack, onNext }) {
           </div>
         </div>
         {/* Derecha: Espacio para gráficos o contenido futuro */}
-        <div style={{ flex: 1, minWidth: 350, maxWidth: 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 0, paddingTop: 0, paddingLeft: 0, marginTop: '3.7rem', alignItems: 'center', justifyContent: 'center' }}>
-          <div style={{ width: 750, height: 600, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: '1.2rem', background: 'transparent', overflow: 'hidden', boxSizing: 'border-box', margin: '0 auto' }}>
+        <div style={{ flex: 1, minWidth: isMobile ? '100%' : 300, maxWidth: isMobile ? '100%' : 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 0, paddingTop: 0, paddingLeft: 0, marginTop: isMobile ? 20 : '3.7rem', alignItems: 'center', justifyContent: 'center' }}>
+          <div style={{ width: tableWidth, height: 600, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: '1.2rem', background: 'transparent', overflow: 'hidden', boxSizing: 'border-box', margin: '0 auto' }}>
             {/* Tabla de mejores calificaciones por criterios invariables1 y CAPAG "A" */}
             <MejoresMunicipiosTable />
           </div>

--- a/src/RegionesFinanciadorPage.jsx
+++ b/src/RegionesFinanciadorPage.jsx
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import { useEffect, useRef, useState } from 'react';
+import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 // Aquí puedes importar tu componente de gráfico específico para esta página si lo necesitas
@@ -22,6 +23,9 @@ export default function RegionesFinanciadorPage({ onBack, onNext }) {
   if (vista === 'todos') acreedoresMostrar = acreedoresTodos;
   const [valoresEnte, setValoresEnte] = useState([]);
   const [mapaTipo, setMapaTipo] = useState('montos'); // 'montos', 'financiador', 'sectores'
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = windowWidth < 768;
+  const chartWidth = Math.min(800, windowWidth - (isMobile ? 40 : 200));
 
   useEffect(() => {
     fetch(`${API_URL}/api/regiones`).then(r => r.json()).then(d => setRegiones(d.regiones));
@@ -97,8 +101,8 @@ export default function RegionesFinanciadorPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          top: 100,
-          right: 32,
+          top: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -123,8 +127,8 @@ export default function RegionesFinanciadorPage({ onBack, onNext }) {
         }}
         style={{
           position: 'fixed',
-          bottom: 100,
-          right: 32,
+          bottom: isMobile ? 80 : 100,
+          right: isMobile ? 16 : 32,
           cursor: 'pointer',
           zIndex: 2000,
           display: 'flex',
@@ -139,27 +143,27 @@ export default function RegionesFinanciadorPage({ onBack, onNext }) {
       >
         <FaArrowUp style={{ fontSize: 36, color: '#c1121f', transform: 'rotate(180deg)' }} />
       </div>
-      <div style={{ display: 'flex', gap: '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: 'calc(100vh - 72px)' }}>
+      <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? '1.5rem' : '2.5rem', alignItems: 'stretch', maxWidth: 1400, margin: '0 auto', padding: '0', flexWrap: 'wrap', height: isMobile ? 'auto' : 'calc(100vh - 72px)' }}>
         {/* Izquierda: Card descriptivo con título y texto */}
         <div
           style={{
             flex: 1,
-            minWidth: 380,
-            maxWidth: 480,
+            minWidth: isMobile ? '100%' : 320,
+            maxWidth: isMobile ? '100%' : 480,
             background: '#fff',
             borderRadius: 0,
             boxShadow: '0 4px 24px #0001',
             border: 'none',
             marginLeft: 0,
-            marginTop: '3.7rem',
+            marginTop: isMobile ? '1.5rem' : '3.7rem',
             marginBottom: 0,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-start',
             padding: '2.5rem 2rem 2rem 2rem',
             boxSizing: 'border-box',
-            height: '100%',
-            minHeight: '100%',
+            height: isMobile ? 'auto' : '100%',
+            minHeight: isMobile ? 'auto' : '100%',
             position: 'relative',
             zIndex: 2,
             width: '100%',
@@ -248,10 +252,10 @@ export default function RegionesFinanciadorPage({ onBack, onNext }) {
           </div>
         </div>
         {/* Derecha: Espacio para gráficos */}
-        <div style={{ flex: 1, minWidth: 350, maxWidth: 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: 56, paddingTop: 0, paddingLeft: 0, marginTop: 100 }}>
+        <div style={{ flex: 1, minWidth: isMobile ? '100%' : 300, maxWidth: isMobile ? '100%' : 700, display: 'flex', flexDirection: 'column', gap: 8, marginLeft: isMobile ? 0 : 56, paddingTop: 0, paddingLeft: 0, marginTop: isMobile ? 60 : 100 }}>
           {/* Aquí puedes agregar los componentes de gráficos que desees */}
           <div style={{ width: '100%', height: 600, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: '1.2rem', background: 'transparent' }}>
-            <MapaBrasilInteractivo width={800} height={600} valoresEnte={valoresEnte} mapaTipo={mapaTipo} />
+            <MapaBrasilInteractivo width={chartWidth} height={600} valoresEnte={valoresEnte} mapaTipo={mapaTipo} />
           </div>
         </div>
       </div>

--- a/src/hooks/useWindowSize.js
+++ b/src/hooks/useWindowSize.js
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export default function useWindowSize() {
+  const [size, setSize] = useState({ width: window.innerWidth, height: window.innerHeight });
+
+  useEffect(() => {
+    function handleResize() {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return size;
+}


### PR DESCRIPTION
## Summary
- add `useWindowSize` hook
- use `useWindowSize` across pages to adapt layouts and chart widths
- tweak inline styles so cards and charts fit smaller screens

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881404df3748330bbfc315c03179fc4