### PR TITLE
Fix API URL formatting in env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-   VITE_API_URL=https://sadipemback-production.up.railway.app
+VITE_API_URL=https://sadipemback-production.up.railway.app


### PR DESCRIPTION
## Summary
- remove leading whitespace from `.env` so Vite properly loads `VITE_API_URL`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bc627e81883308f56b3aecdbac7f4