### PR TITLE
Improve data fetching efficiency with caching

### DIFF
--- a/src/BrasilPage.jsx
+++ b/src/BrasilPage.jsx
@@ -1,9 +1,9 @@
 import * as d3 from 'd3';
-import { useEffect, useRef } from 'react';
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
+import useCachedFetch from './hooks/useCachedFetch';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -177,88 +177,95 @@ function BarChartD3({ data, width = 520, height = 240, colorMap, showXAxis = tru
 }
 
 export default function BrasilPage({ onBack, onNext }) {
-  const [regiones, setRegiones] = useState([]);
-  const [sectores, setSectores] = useState([]);
   const [region, setRegion] = useState('');
   const [sector, setSector] = useState('');
-  const [datos, setDatos] = useState([]);
-
-  useEffect(() => {
-    fetch(`${API_URL}/api/regiones`).then(r => r.json()).then(d => setRegiones(d.regiones));
-    fetch(`${API_URL}/api/sectores`).then(r => r.json()).then(d => setSectores(d.sectores));
-  }, []);
-
-  useEffect(() => {
-    let url = `${API_URL}/api/datos`;
+  const queryString = useMemo(() => {
     const params = [];
     if (region) params.push(`region=${encodeURIComponent(region)}`);
     if (sector) params.push(`sector=${encodeURIComponent(sector)}`);
-    if (params.length) url += `?${params.join('&')}`;
-    fetch(url).then(r => r.json()).then(setDatos);
+    return params.length ? `?${params.join('&')}` : '';
   }, [region, sector]);
+  const datosResponse = useCachedFetch(`${API_URL}/api/datos${queryString}`, { initialData: [] });
+  const datos = Array.isArray(datosResponse.data) ? datosResponse.data : [];
 
   // Datos para los gráficos
   const colorMap = { 'Externo': '#c1121f', 'Interno': '#888' };
   // Filtrar solo Município
-  const datosMunicipio = datos.filter(d => d.tipo_ente === 'Município');
-  const datosGraf1 = datosMunicipio.filter(d => {
-    const year = new Date(d.fecha_contratacion).getFullYear();
-    return year !== 2009;
-  });
-  const datosGraf2 = datosMunicipio.filter(d => d.tiempo_prestamo > 13);
+  const datosMunicipio = useMemo(
+    () => datos.filter(d => d.tipo_ente === 'Município'),
+    [datos]
+  );
+  const datosGraf1 = useMemo(() => {
+    return datosMunicipio.filter(d => {
+      const year = new Date(d.fecha_contratacion).getFullYear();
+      return year !== 2009;
+    });
+  }, [datosMunicipio]);
+  const datosGraf2 = useMemo(
+    () => datosMunicipio.filter(d => d.tiempo_prestamo > 13),
+    [datosMunicipio]
+  );
 
   const { width: windowWidth } = useWindowSize();
   const isMobile = windowWidth < 768;
 
   // Cálculo de métricas para los botones
-  // Promedio anual de aprobaciones EXTERNAS últimos 5 años (en millones USD)
-  const now = new Date();
-  const lastYear = now.getFullYear();
-  const datosUlt5Externo = datosMunicipio.filter(d => {
-    const year = new Date(d.fecha_contratacion).getFullYear();
-    return year >= lastYear - 4 && year <= lastYear && d.RGF_clasificacion === 'Externo';
-  });
-  const totalAprobUlt5Externo = datosUlt5Externo.reduce((sum, d) => sum + (d.valor_usd || 0), 0);
-  const promAprobUlt5 = totalAprobUlt5Externo / 5 / 1e6; // millones USD solo externos
+  const lastYear = useMemo(() => new Date().getFullYear(), []);
+  const {
+    promAprobUlt5,
+    promFonplata,
+    tablaPlazos,
+  } = useMemo(() => {
+    const datosUlt5Externo = datosMunicipio.filter(d => {
+      const year = new Date(d.fecha_contratacion).getFullYear();
+      return year >= lastYear - 4 && year <= lastYear && d.RGF_clasificacion === 'Externo';
+    });
+    const totalAprobUlt5Externo = datosUlt5Externo.reduce((sum, d) => sum + (d.valor_usd || 0), 0);
+    const promAprob = totalAprobUlt5Externo / 5 / 1e6;
 
-  // Definir datosUlt5 para todos los préstamos de los últimos 5 años
-  const datosUlt5 = datosMunicipio.filter(d => {
-    const year = new Date(d.fecha_contratacion).getFullYear();
-    return year >= lastYear - 4 && year <= lastYear;
-  });
+    const datosUlt5 = datosMunicipio.filter(d => {
+      const year = new Date(d.fecha_contratacion).getFullYear();
+      return year >= lastYear - 4 && year <= lastYear;
+    });
 
-  // Promedio de financiamiento solo FONPLATA últimos 5 años
-  const datosFonplata = datosUlt5.filter(d => d.nombre_acreedor && d.nombre_acreedor.toUpperCase().includes('FONPLATA'));
-  const totalFonplata = datosFonplata.reduce((sum, d) => sum + (d.valor_usd || 0), 0);
-  const promFonplata = totalFonplata / 5 / 1e6; // millones USD
+    const datosFonplata = datosUlt5.filter(d => d.nombre_acreedor && d.nombre_acreedor.toUpperCase().includes('FONPLATA'));
+    const totalFonplata = datosFonplata.reduce((sum, d) => sum + (d.valor_usd || 0), 0);
+    const promFonplataCalc = totalFonplata / 5 / 1e6;
 
-  // Calcular tabla de % Externa por rango de plazo según instrucciones detalladas
-  const plazos = [
-    { label: 'Menor a 5 años', min: 0, max: 4 },
-    { label: '5 a 8 años', min: 5, max: 8 },
-    { label: '9 a 13 años', min: 9, max: 13 },
-    { label: '15 a 20 años', min: 15, max: 20 },
-    { label: 'Mayor a 20 años', min: 21, max: 1000 },
-  ];
-  // Paso 1: Filtrar base de datos
-  const datosFiltrados = datosMunicipio.filter(d =>
-    d.garantia_soberana === 'Si' &&
-    d.tiempo_prestamo !== null && d.tiempo_prestamo !== undefined &&
-    (() => { const y = new Date(d.fecha_contratacion).getFullYear(); return y >= 2020 && y <= 2024; })() &&
-    (d.RGF_clasificacion === 'Externo' || d.RGF_clasificacion === 'Interno')
-  );
-  // Paso 2 y 3: Clasificar y agrupar
-  const tablaPlazos = plazos.map(rango => {
-    const prestamosRango = datosFiltrados.filter(d => d.tiempo_prestamo >= rango.min && d.tiempo_prestamo <= rango.max);
-    const total = prestamosRango.length;
-    const externos = prestamosRango.filter(d => d.RGF_clasificacion === 'Externo').length;
+    const plazos = [
+      { label: 'Menor a 5 años', min: 0, max: 4 },
+      { label: '5 a 8 años', min: 5, max: 8 },
+      { label: '9 a 13 años', min: 9, max: 13 },
+      { label: '15 a 20 años', min: 15, max: 20 },
+      { label: 'Mayor a 20 años', min: 21, max: 1000 },
+    ];
+    const datosFiltrados = datosMunicipio.filter(d =>
+      d.garantia_soberana === 'Si' &&
+      d.tiempo_prestamo !== null && d.tiempo_prestamo !== undefined &&
+      (() => { const y = new Date(d.fecha_contratacion).getFullYear(); return y >= 2020 && y <= 2024; })() &&
+      (d.RGF_clasificacion === 'Externo' || d.RGF_clasificacion === 'Interno')
+    );
+    const tabla = plazos.map(rango => {
+      const prestamosRango = datosFiltrados.filter(d => d.tiempo_prestamo >= rango.min && d.tiempo_prestamo <= rango.max);
+      const total = prestamosRango.length;
+      const externos = prestamosRango.filter(d => d.RGF_clasificacion === 'Externo').length;
+      return {
+        plazo: rango.label,
+        porcentajeExterna: total > 0 ? (100 * externos / total).toFixed(1) : '0.0'
+      };
+    });
+
     return {
-      plazo: rango.label,
-      porcentajeExterna: total > 0 ? (100 * externos / total).toFixed(1) : '0.0'
+      promAprobUlt5: promAprob,
+      promFonplata: promFonplataCalc,
+      tablaPlazos: tabla,
     };
-  });
+  }, [datosMunicipio, lastYear]);
 
-  const chartWidth = Math.min(600, windowWidth - (isMobile ? 40 : 200));
+  const chartWidth = useMemo(
+    () => Math.min(600, windowWidth - (isMobile ? 40 : 200)),
+    [windowWidth, isMobile]
+  );
 
   return (
     <div style={{ background: '#f7f7f9', padding: '0', position: 'relative' }}>

--- a/src/DescripcionMercadoPage.jsx
+++ b/src/DescripcionMercadoPage.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 import ScatterPlot from './components/ScatterPlot';
+import useCachedFetch from './hooks/useCachedFetch';
 
 const acreedoresTodos = ['BIRF', 'BID', 'CAF', 'FONPLATA', 'Caixa', 'NDB', 'BNDS'];
 const acreedoresExternos = ['BIRF', 'BID', 'CAF', 'FONPLATA'];
@@ -16,14 +17,21 @@ function getAcreedores(vista) {
 }
 
 export default function DescripcionMercadoPage({ onBack, onNext }) {
-  const [datos, setDatos] = useState([]);
   const API_URL = import.meta.env.VITE_API_URL;
   const [vista, setVista] = useState('todos');
   const [ocultos, setOcultos] = useState([]); // categorías ocultas
   const [yMax, setYMax] = useState(115);
   const { width: windowWidth } = useWindowSize();
   const isMobile = windowWidth < 768;
-  const chartWidth = Math.min(650, windowWidth - (isMobile ? 40 : 200));
+  const chartWidth = useMemo(
+    () => Math.min(650, windowWidth - (isMobile ? 40 : 200)),
+    [windowWidth, isMobile]
+  );
+  const datosResponse = useCachedFetch(`${API_URL}/api/datos`, { initialData: [] });
+  const datos = useMemo(
+    () => (Array.isArray(datosResponse.data) ? datosResponse.data : []),
+    [datosResponse.data]
+  );
 
   // Altura y margen del área útil del gráfico
   const plotHeight = 500; // 600 - 40 (top) - 60 (bottom)
@@ -40,10 +48,6 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
   // Filtrar acreedores según los ocultos
   const acreedoresFiltrados = acreedoresMostrar.filter(a => !ocultos.includes(a));
 
-  useEffect(() => {
-    fetch(`${API_URL}/api/datos`).then(r => r.json()).then(setDatos);
-  }, [API_URL]);
-
   // Si cambia la vista, restaurar la lista de ocultos
   useEffect(() => {
     if (vista === 'todos') {
@@ -55,12 +59,15 @@ export default function DescripcionMercadoPage({ onBack, onNext }) {
 
   // Calcular el máximo valor de los datos (en millones)
   const LIMITE_MAXIMO = 750; // 750 millones
-  const maxDatos = Math.ceil(Math.max(1, ...datos.map(d => (d.valor_usd || 0) / 1e6)));
+  const maxDatos = useMemo(
+    () => Math.ceil(Math.max(1, ...datos.map(d => (d.valor_usd || 0) / 1e6))),
+    [datos]
+  );
   const maxValor = LIMITE_MAXIMO;
   useEffect(() => {
     if (yMax === null) setYMax(115);
     else if (yMax > LIMITE_MAXIMO) setYMax(LIMITE_MAXIMO);
-  }, [maxValor]);
+  }, [maxValor, yMax]);
 
   // Handler para click en la leyenda
   const handleToggleAcreedor = (acreedor) => {

--- a/src/FinanciadorMontosPage.jsx
+++ b/src/FinanciadorMontosPage.jsx
@@ -1,9 +1,9 @@
-import * as d3 from 'd3';
-import { useEffect, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 import BoxPlot from './components/BoxPlot';
+import useCachedFetch from './hooks/useCachedFetch';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -11,11 +11,8 @@ const API_URL = import.meta.env.VITE_API_URL;
 
 export default function FinanciadorMontosPage({ onBack, onNext }) {
   // Estados para datos, regiones, sectores, etc. (puedes adaptar según la lógica que necesites)
-  const [regiones, setRegiones] = useState([]);
-  const [sectores, setSectores] = useState([]);
   const [region, setRegion] = useState('');
   const [sector, setSector] = useState('');
-  const [datos, setDatos] = useState([]);
   const [vista, setVista] = useState('exteriores');
   // Listas de acreedores para cada vista
   const acreedoresExteriores = ['FONPLATA', 'BID', 'NDB', 'CAF', 'BIRF'];
@@ -23,24 +20,22 @@ export default function FinanciadorMontosPage({ onBack, onNext }) {
   const acreedoresTodos = ['Caixa', 'FONPLATA', 'BNDS', 'BID', 'NDB', 'CAF', 'BIRF'];
   const { width: windowWidth } = useWindowSize();
   const isMobile = windowWidth < 768;
-  const chartWidth = Math.min(700, windowWidth - (isMobile ? 40 : 200));
+  const chartWidth = useMemo(
+    () => Math.min(700, windowWidth - (isMobile ? 40 : 200)),
+    [windowWidth, isMobile]
+  );
   let acreedoresMostrar = acreedoresExteriores;
   if (vista === 'internos') acreedoresMostrar = acreedoresInternos;
   if (vista === 'todos') acreedoresMostrar = acreedoresTodos;
 
-  useEffect(() => {
-    fetch(`${API_URL}/api/regiones`).then(r => r.json()).then(d => setRegiones(d.regiones));
-    fetch(`${API_URL}/api/sectores`).then(r => r.json()).then(d => setSectores(d.sectores));
-  }, []);
-
-  useEffect(() => {
-    let url = `${API_URL}/api/datos`;
+  const queryString = useMemo(() => {
     const params = [];
     if (region) params.push(`region=${encodeURIComponent(region)}`);
     if (sector) params.push(`sector=${encodeURIComponent(sector)}`);
-    if (params.length) url += `?${params.join('&')}`;
-    fetch(url).then(r => r.json()).then(setDatos);
+    return params.length ? `?${params.join('&')}` : '';
   }, [region, sector]);
+  const datosResponse = useCachedFetch(`${API_URL}/api/datos${queryString}`, { initialData: [] });
+  const datos = Array.isArray(datosResponse.data) ? datosResponse.data : [];
 
   return (
     <div style={{ background: '#f7f7f9', padding: '0', position: 'relative' }}>

--- a/src/RegionesFinanciadorPage.jsx
+++ b/src/RegionesFinanciadorPage.jsx
@@ -1,18 +1,14 @@
 import * as d3 from 'd3';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import useWindowSize from './hooks/useWindowSize';
 import { FaArrowUp } from 'react-icons/fa';
 import fonpilogo from './assets/fonpilogo.png';
 // Aquí puedes importar tu componente de gráfico específico para esta página si lo necesitas
+import useCachedFetch from './hooks/useCachedFetch';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
 export default function RegionesFinanciadorPage({ onBack, onNext }) {
-  const [regiones, setRegiones] = useState([]);
-  const [sectores, setSectores] = useState([]);
-  const [region, setRegion] = useState('');
-  const [sector, setSector] = useState('');
-  const [datos, setDatos] = useState([]);
   const [vista, setVista] = useState('exteriores');
   // Listas de acreedores para cada vista
   const acreedoresExteriores = ['FONPLATA', 'BID', 'NDB', 'CAF', 'BIRF'];
@@ -21,32 +17,21 @@ export default function RegionesFinanciadorPage({ onBack, onNext }) {
   let acreedoresMostrar = acreedoresExteriores;
   if (vista === 'internos') acreedoresMostrar = acreedoresInternos;
   if (vista === 'todos') acreedoresMostrar = acreedoresTodos;
-  const [valoresEnte, setValoresEnte] = useState([]);
   const [mapaTipo, setMapaTipo] = useState('montos'); // 'montos', 'financiador', 'sectores'
   const { width: windowWidth } = useWindowSize();
   const isMobile = windowWidth < 768;
-  const chartWidth = Math.min(800, windowWidth - (isMobile ? 40 : 200));
-
-  useEffect(() => {
-    fetch(`${API_URL}/api/regiones`).then(r => r.json()).then(d => setRegiones(d.regiones));
-    fetch(`${API_URL}/api/sectores`).then(r => r.json()).then(d => setSectores(d.sectores));
-  }, []);
-
-  useEffect(() => {
-    let url = `${API_URL}/api/datos`;
-    const params = [];
-    if (region) params.push(`region=${encodeURIComponent(region)}`);
-    if (sector) params.push(`sector=${encodeURIComponent(sector)}`);
-    if (params.length) url += `?${params.join('&')}`;
-    fetch(url).then(r => r.json()).then(setDatos);
-  }, [region, sector]);
-
-  useEffect(() => {
-    fetch(`${API_URL}/api/valores_ente`).then(r => r.json()).then(setValoresEnte);
-  }, []);
+  const chartWidth = useMemo(
+    () => Math.min(800, windowWidth - (isMobile ? 40 : 200)),
+    [windowWidth, isMobile]
+  );
+  const valoresEnteResponse = useCachedFetch(`${API_URL}/api/valores_ente`, { initialData: [] });
+  const valoresEnte = Array.isArray(valoresEnteResponse.data) ? valoresEnteResponse.data : [];
 
   // Filtrar valoresEnte solo con garantia_soberana 'Si'
-  const valoresEnteFiltrados = valoresEnte.filter(v => (v.garantia_soberana === 'Si'));
+  const valoresEnteFiltrados = useMemo(
+    () => valoresEnte.filter(v => (v.garantia_soberana === 'Si')),
+    [valoresEnte]
+  );
 
   return (
     <div style={{ background: '#f7f7f9', padding: '0', position: 'relative' }}>

--- a/src/hooks/useCachedFetch.js
+++ b/src/hooks/useCachedFetch.js
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const responseCache = new Map();
+
+/**
+ * Simple fetch hook with in-memory caching to avoid refetching the same GET requests.
+ * Returns the cached value immediately when available and keeps track of the loading state.
+ */
+export default function useCachedFetch(url, { enabled = true, initialData = null } = {}) {
+  const cacheKey = useMemo(() => (url && enabled ? url : null), [url, enabled]);
+  const [data, setData] = useState(() => {
+    if (cacheKey && responseCache.has(cacheKey)) {
+      return responseCache.get(cacheKey);
+    }
+    return initialData ?? null;
+  });
+  const [loading, setLoading] = useState(() => Boolean(cacheKey && !responseCache.has(cacheKey) && initialData === null));
+  const [error, setError] = useState(null);
+  const [reloadIndex, setReloadIndex] = useState(0);
+
+  useEffect(() => {
+    if (!cacheKey) {
+      setLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchData = async () => {
+      if (responseCache.has(cacheKey)) {
+        setData(responseCache.get(cacheKey));
+        setLoading(false);
+        setError(null);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch(cacheKey);
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const json = await response.json();
+        responseCache.set(cacheKey, json);
+        if (isMounted) {
+          setData(json);
+          setError(null);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [cacheKey, reloadIndex]);
+
+  const refetch = useCallback((force = false) => {
+    if (!cacheKey) return;
+    if (force) {
+      responseCache.delete(cacheKey);
+    }
+    setReloadIndex(index => index + 1);
+  }, [cacheKey]);
+
+  return { data, loading, error, refetch };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useCachedFetch` hook to cache GET responses and expose a refetch helper
- refactor the Brasil, Financiador por Montos, Regiones por Financiador, and Descripción de Mercado pages to use cached data and memoized calculations for chart inputs
- memoize expensive derived datasets and layout sizes to reduce unnecessary recomputation during renders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8f34634688330818f8a9894bcec21